### PR TITLE
Feat/006 Tabs, Radio Custom, ButtonCheckBox, ButtonCheckBox Group 추가

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,7 @@
 import { ThemeProvider } from "@mui/material";
 import Theme from "@/styles/theme";
+import { Global } from "@emotion/react";
+import reset from "@/styles/reset";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -14,6 +16,7 @@ export const parameters = {
 export const decorators = [
   (Story) => (
     <ThemeProvider theme={Theme}>
+      <Global styles={reset} />
       <Story />
     </ThemeProvider>
   ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10995,6 +10995,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -11010,7 +11012,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -34086,15 +34090,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -34106,7 +34109,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/src/components/ButtonCheckBox/ButtonCheckBox.tsx
+++ b/src/components/ButtonCheckBox/ButtonCheckBox.tsx
@@ -9,7 +9,7 @@ interface ButtonCheckBoxProps {
   disableRipple?: boolean;
   btnColor?: string;
   checkedBtnColor?: string;
-  btnStyle?: any; // custom style for button
+  btnStyle?: React.CSSProperties; // custom style for button
 }
 
 const ButtonCheckBox = ({

--- a/src/components/ButtonCheckBoxGroup/ButtonCheckBoxGroup.tsx
+++ b/src/components/ButtonCheckBoxGroup/ButtonCheckBoxGroup.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { FormGroup, FormControl, FormLabel } from "@mui/material";
+import ButtonCheckBox from "@/components/ButtonCheckBox";
+
+interface ButtonCheckBoxGroupProps {
+  data: {
+    id: string | number;
+    text: string | number;
+    others?: any; // other props(optional)
+  }[];
+  btnColor?: string;
+  checkedBtnColor?: string;
+  btnStyle?: React.CSSProperties;
+  label?: string;
+  variant?: "filled" | "outlined" | "standard";
+}
+
+const ButtonCheckBoxGroup = React.forwardRef<
+  HTMLButtonElement,
+  ButtonCheckBoxGroupProps
+>(
+  (
+    {
+      btnColor,
+      checkedBtnColor,
+      btnStyle,
+      label,
+      variant = "standard",
+      data = [],
+      ...props
+    },
+    ref
+  ) => (
+    <FormControl component="fieldset" variant={variant}>
+      {label && <FormLabel component="legend">{label}</FormLabel>}
+      <FormGroup>
+        {data.map(({ id, text, others }) => (
+          <ButtonCheckBox
+            key={id}
+            text={text}
+            btnColor={btnColor}
+            checkedBtnColor={checkedBtnColor}
+            btnStyle={btnStyle}
+            {...props}
+            value={text}
+            inputProps={{
+              "data-id": text,
+            }}
+            inputRef={ref}
+            disableRipple
+            {...others} // other checkbox props(ex => style)
+          />
+        ))}
+      </FormGroup>
+    </FormControl>
+  )
+);
+
+export default ButtonCheckBoxGroup;

--- a/src/components/ButtonCheckBoxGroup/ButtonCheckBoxGroup.tsx
+++ b/src/components/ButtonCheckBoxGroup/ButtonCheckBoxGroup.tsx
@@ -6,6 +6,7 @@ interface ButtonCheckBoxGroupProps {
   data: {
     id: string | number;
     text: string | number;
+    value: string | number;
     others?: any; // other props(optional)
   }[];
   btnColor?: string;
@@ -34,7 +35,7 @@ const ButtonCheckBoxGroup = React.forwardRef<
     <FormControl component="fieldset" variant={variant}>
       {label && <FormLabel component="legend">{label}</FormLabel>}
       <FormGroup>
-        {data.map(({ id, text, others }) => (
+        {data.map(({ id, text, value, others }) => (
           <ButtonCheckBox
             key={id}
             text={text}
@@ -42,7 +43,7 @@ const ButtonCheckBoxGroup = React.forwardRef<
             checkedBtnColor={checkedBtnColor}
             btnStyle={btnStyle}
             {...props}
-            value={text}
+            value={value}
             inputProps={{
               "data-id": text,
             }}

--- a/src/components/ButtonCheckBoxGroup/index.ts
+++ b/src/components/ButtonCheckBoxGroup/index.ts
@@ -1,0 +1,3 @@
+import ButtonCheckBoxGroup from "./ButtonCheckBoxGroup";
+
+export default ButtonCheckBoxGroup;

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,0 +1,31 @@
+import { Divider as MuiDivider } from "@mui/material";
+
+interface CustomDividerProps {
+  variant?: "fullWidth" | "inset" | "middle";
+  direction?: "horizontal" | "vertical";
+  textAlign?: "left" | "center" | "right";
+  flexItem?: boolean;
+  children?: React.ReactNode;
+  component?: React.ElementType;
+}
+
+const Divider = ({
+  variant,
+  direction,
+  textAlign,
+  flexItem,
+  children,
+  ...props
+}: CustomDividerProps) => (
+  <MuiDivider
+    variant={variant}
+    orientation={direction}
+    textAlign={textAlign}
+    flexItem={flexItem}
+    {...props}
+  >
+    {children}
+  </MuiDivider>
+);
+
+export default Divider;

--- a/src/components/Divider/index.ts
+++ b/src/components/Divider/index.ts
@@ -1,0 +1,3 @@
+import Divider from "./Divider";
+
+export default Divider;

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React from "react";
 import {
   RadioGroupProps,
@@ -25,6 +26,21 @@ interface CustomRadioProps extends RadioGroupProps {
   error?: boolean;
   errorMessage?: string;
   defaultValue?: string | number;
+  useCustomIcon?: boolean;
+  icon?: ({
+    label,
+    type,
+  }: {
+    label: string | number;
+    type: string;
+  }) => JSX.Element;
+  checkedIcon?: ({
+    label,
+    type,
+  }: {
+    label: string | number;
+    type: string;
+  }) => JSX.Element;
 }
 
 const Radio = React.forwardRef<HTMLButtonElement, CustomRadioProps>(
@@ -41,6 +57,9 @@ const Radio = React.forwardRef<HTMLButtonElement, CustomRadioProps>(
       error,
       errorMessage,
       defaultValue,
+      useCustomIcon,
+      icon,
+      checkedIcon,
       ...props
     },
     ref
@@ -68,10 +87,21 @@ const Radio = React.forwardRef<HTMLButtonElement, CustomRadioProps>(
                   customsize={customSize}
                   color={color}
                   customcolor={customColor}
+                  icon={
+                    useCustomIcon
+                      ? icon && icon({ label: dataLabel, type: "notChecked" })
+                      : undefined
+                  }
+                  checkedIcon={
+                    useCustomIcon
+                      ? checkedIcon &&
+                        checkedIcon({ label: dataLabel, type: "checked" })
+                      : undefined
+                  }
                   ref={ref}
                 />
               }
-              label={dataLabel}
+              label={useCustomIcon ? undefined : dataLabel}
               disabled={disabled}
             />
           ))}

--- a/src/components/Tabs/TabPanel/TabPanel.tsx
+++ b/src/components/Tabs/TabPanel/TabPanel.tsx
@@ -1,0 +1,13 @@
+interface TabPanelProps {
+  children?: React.ReactNode;
+  currentValue: number | string;
+  tabValue: number | string;
+}
+
+const TabPanel = ({ children, currentValue, tabValue }: TabPanelProps) => (
+  <div hidden={currentValue !== tabValue}>
+    {currentValue === tabValue && children}
+  </div>
+);
+
+export default TabPanel;

--- a/src/components/Tabs/TabPanel/index.ts
+++ b/src/components/Tabs/TabPanel/index.ts
@@ -1,0 +1,3 @@
+import TabPanel from "./TabPanel";
+
+export default TabPanel;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,41 @@
+import { Tab, Tabs as MuiTabs } from "@mui/material";
+import useTabs from "@/hooks/useTabs";
+import TabPanel from "./TabPanel";
+
+interface TabProps {
+  data?: {
+    label: string;
+    value: number | string;
+    disabled?: boolean;
+  }[];
+  renderData?: {
+    value: number | string;
+    targetData?: React.ReactNode;
+  }[];
+  direction?: "horizontal" | "vertical";
+}
+
+const Tabs = ({
+  data = [],
+  renderData = [],
+  direction = "horizontal",
+}: TabProps) => {
+  const [tabValue, handleTabs] = useTabs(data[0]?.value);
+
+  return (
+    <>
+      <MuiTabs value={tabValue} onChange={handleTabs} orientation={direction}>
+        {data.map(({ label, value, disabled }) => (
+          <Tab key={value} label={label} value={value} disabled={disabled} />
+        ))}
+      </MuiTabs>
+      {renderData?.map(({ value, targetData }) => (
+        <TabPanel key={value} currentValue={tabValue} tabValue={value}>
+          {targetData}
+        </TabPanel>
+      ))}
+    </>
+  );
+};
+
+export default Tabs;

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,0 +1,3 @@
+import Tabs from "./Tabs";
+
+export default Tabs;

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,0 +1,34 @@
+import { Typography, TypographyProps } from "@mui/material";
+
+interface CustomTypographyProps {
+  variant?: TypographyProps["variant"];
+  marginBottom?: boolean;
+  noWrap?: boolean;
+  paragraph?: boolean;
+  align?: TypographyProps["align"];
+  textStyle?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+const Text = ({
+  variant,
+  marginBottom,
+  noWrap,
+  paragraph,
+  align,
+  textStyle,
+  children,
+}: CustomTypographyProps) => (
+  <Typography
+    variant={variant}
+    gutterBottom={marginBottom}
+    noWrap={noWrap}
+    paragraph={paragraph}
+    align={align}
+    style={textStyle}
+  >
+    {children}
+  </Typography>
+);
+
+export default Text;

--- a/src/components/Text/index.ts
+++ b/src/components/Text/index.ts
@@ -1,0 +1,3 @@
+import Text from "./Text";
+
+export default Text;

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -1,0 +1,16 @@
+import { useState } from "react";
+
+const useTabs = (initialValue: number | string) => {
+  const [value, setValue] = useState<number | string>(initialValue);
+
+  const handleChange = (
+    event: React.SyntheticEvent,
+    newValue: number | string
+  ) => {
+    setValue(newValue);
+  };
+
+  return [value, handleChange] as const;
+};
+
+export default useTabs;

--- a/src/stories/ButtonCheckBox.stories.tsx
+++ b/src/stories/ButtonCheckBox.stories.tsx
@@ -1,5 +1,7 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { useForm } from "react-hook-form";
 import ButtonCheckBox from "@/components/ButtonCheckBox";
+import ButtonCheckBoxGroup from "@/components/ButtonCheckBoxGroup";
 
 export default {
   title: "Custom/ButtonCheckBox",
@@ -33,4 +35,36 @@ CustomButtonStyle.args = {
   btnColor: "red",
   checkedBtnColor: "blue",
   btnStyle: customStyle,
+};
+
+const DATA = [
+  { id: 0, text: "One" },
+  { id: 1, text: "Two" },
+  { id: 2, text: "Three" },
+  { id: 3, text: "Four" },
+];
+
+type GroupTypes = {
+  test: (string | number | undefined)[];
+};
+
+export const CustomButtonStyleGroup: ComponentStory<
+  typeof ButtonCheckBoxGroup
+> = () => {
+  const { register, handleSubmit } = useForm<GroupTypes>();
+
+  const onSubmit = (data: any) => {
+    console.log(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <ButtonCheckBoxGroup
+        label="ButtonCheckBoxGroup"
+        data={DATA}
+        {...register("test")}
+      />
+      <button type="submit">submit</button>
+    </form>
+  );
 };

--- a/src/stories/ButtonCheckBox.stories.tsx
+++ b/src/stories/ButtonCheckBox.stories.tsx
@@ -38,10 +38,10 @@ CustomButtonStyle.args = {
 };
 
 const DATA = [
-  { id: 0, text: "One" },
-  { id: 1, text: "Two" },
-  { id: 2, text: "Three" },
-  { id: 3, text: "Four" },
+  { id: 0, text: "One", value: "one" },
+  { id: 1, text: "Two", value: "two" },
+  { id: 2, text: "Three", value: "three" },
+  { id: 3, text: "Four", value: "four" },
 ];
 
 type GroupTypes = {

--- a/src/stories/Divider.stories.tsx
+++ b/src/stories/Divider.stories.tsx
@@ -1,0 +1,13 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import Divider from "@/components/Divider";
+
+export default {
+  title: "MUI/Divider",
+  component: Divider,
+} as ComponentMeta<typeof Divider>;
+
+export const Default: ComponentStory<typeof Divider> = () => <Divider />;
+
+export const ComponentSample: ComponentStory<typeof Divider> = () => (
+  <Divider component="div" />
+);

--- a/src/stories/Radio.stories.tsx
+++ b/src/stories/Radio.stories.tsx
@@ -1,6 +1,8 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import styled from "@emotion/styled";
 import { useForm } from "react-hook-form";
 import React from "react";
+import Button from "@/components/Button";
 import Radio from "@/components/Radio";
 
 export default {
@@ -89,3 +91,31 @@ export const WithForm: ComponentStory<typeof Radio> = () => {
     </form>
   );
 };
+
+const CheckedIcon = styled(Button)`
+  background-color: red;
+`;
+
+const RadioIconButton = ({
+  label,
+  type,
+}: {
+  label: string | number;
+  type: string;
+}) =>
+  type === "checked" ? (
+    <CheckedIcon>{label}</CheckedIcon>
+  ) : (
+    <Button>{label}</Button>
+  );
+
+export const CustomIcon: ComponentStory<typeof Radio> = () => (
+  <Radio
+    label="custom icon"
+    id="custom-icon-radio-example"
+    useCustomIcon
+    icon={RadioIconButton}
+    checkedIcon={RadioIconButton}
+    data={DATA}
+  />
+);

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import Tabs from "@/components/Tabs";
+
+export default {
+  title: "MUI/Tabs",
+  component: Tabs,
+} as ComponentMeta<typeof Tabs>;
+
+const DATA = [
+  { label: "One", value: "one" },
+  { label: "Two", value: "two" },
+  { label: "Three", value: "three" },
+];
+
+const RENDER_DATA = [
+  { value: "one", targetData: <span>Hello!</span> },
+  { value: "two", targetData: <span>World!</span> },
+  { value: "three", targetData: <span>Goodbye!</span> },
+];
+
+export const Default: ComponentStory<typeof Tabs> = () => (
+  <Tabs data={DATA} renderData={RENDER_DATA} />
+);

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -13,7 +13,7 @@ const DATA = [
 ];
 
 const RENDER_DATA = [
-  { value: "one", targetData: <span>Hello!</span> },
+  { value: "one", targetData: <span>Hello</span> },
   { value: "two", targetData: <span>World!</span> },
   { value: "three", targetData: <span>Goodbye!</span> },
 ];

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import Text from "@/components/Text";
+
+export default {
+  title: "MUI/Text",
+  component: Text,
+} as ComponentMeta<typeof Text>;
+
+export const Default: ComponentStory<typeof Text> = () => (
+  <>
+    <Text>Default</Text>
+    <Text variant="h1">h1</Text>
+    <Text variant="h2">h2 타이포 그래피 테스트</Text>
+  </>
+);

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -8,6 +8,13 @@ const reset = css`
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
   }
+  @font-face {
+    font-family: "Pretendard-Regular";
+    src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
+      format("woff");
+    font-weight: 400;
+    font-style: normal;
+  }
 `;
 
 export default reset;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -19,6 +19,9 @@ const theme = createTheme({
       },
     },
   },
+  typography: {
+    fontFamily: ["Pretendard-Regular", "Roboto", "sans-serif"].join(","),
+  },
 });
 
 export default theme;


### PR DESCRIPTION
## **📌 PR 설명**
Tabs, Radio Custom, ButtonCheckBox, ButtonCheckBox Group 

## **💻 요구 사항과 구현 내용**
- Tabs, Radio, ButtonCheckBox Group 컴포넌트는 필수적으로 data prop을 전달 해주어야 합니다.
  - 각 data의 shape은 storybook에 명시되어 있습니다. (아니면 각 컴포넌트 파일을 확인해 보시면 필요한 type들을 보실 수 있습니다)
- Tabs는 data와 renderData를 전달 해주어야 합니다. (renderData는 말 그대로 렌더링 할 target 입니다. 해당 탭에 해당하는 페이지 컴포넌트나 컴포넌트를 추가해주시면 될 듯합니다.)
- ~~ButtonCheckBox Group에서 각 checkbox의 value는 box의 text를 기준으로 설정됩니다. 즉 data의 text 속성은 중복되어서는 안됩니다.~~ data에 value 속성을 추가하였습니다. (value 값은 중복되어서는 안됩니다)
  - ButtonCheckBox는 궁극적으로 데이터가 배열형식을 가지고 있습니다. (storybook 예시를 통해 확인 가능합니다.)
- 기타 사항들은 모두 storybook에 정리되어 있습니다. (사용법은 storybook 파일을 보시면 됩니다)
## **✔️ PR 포인트 & 궁금한 점**
