### PR TITLE
[feat] 최초 로그인 후 유저 추가 정보 입력

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 dist/
 .env
+.env.production
 
 DS_Store
 .eslintcache

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import LoginPage from "@/pages/LoginPage";
 import PostPage from "@/pages/PostPage";
 import AuthRoute from "@/routes/AuthRoute";
 import RequireAuth from "@/routes/PrivateRoute";
+import RegisterPage from "./pages/RegisterPage";
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
           <Route path="/" element={<Layout />}>
             <Route index element={<MainPage />} />
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/register" element={<RegisterPage />} />
           </Route>
           <Route element={<RequireAuth />}>
             <Route path="/post" element={<PostPage />} />

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,24 @@
+import axiosInstance from "./axiosInstance";
+
+export interface RegisterData {
+  nickname: string;
+  phoneNumber: string;
+  ridingStartYear?: number;
+  favoriteRegionCode?: number;
+  level: string;
+  bicycles: string[];
+}
+const register = async (registerData: RegisterData) => {
+  try {
+    const res = await axiosInstance({
+      method: "POST",
+      url: "/users/register",
+      data: registerData,
+    });
+    return res.data;
+  } catch (error) {
+    throw new Error("register Profile Failed");
+  }
+};
+
+export default { register };

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -49,7 +49,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       defaultValue,
       InputLabelProps,
       type = "text",
-      inputRef,
       ...props
     },
     ref
@@ -84,7 +83,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         defaultValue={defaultValue}
         InputLabelProps={InputLabelProps}
         type={type}
-        inputRef={inputRef}
         {...props}
       />
     );

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React from "react";
 import {
   RadioGroupProps,
@@ -81,6 +80,7 @@ const Radio = React.forwardRef<HTMLButtonElement, CustomRadioProps>(
             <FormControlLabel
               key={value}
               value={value}
+              sx={{ margin: 0 }}
               control={
                 <CustomRadio
                   size={size}

--- a/src/components/WithLabel/WithLabel.style.ts
+++ b/src/components/WithLabel/WithLabel.style.ts
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+
+interface WithLabelProps {
+  width?: number;
+}
+
+export const Container = styled.div<WithLabelProps>`
+  width: ${({ width }) => (width ? `${width}px` : "100%")};
+`;

--- a/src/components/WithLabel/WithLabel.tsx
+++ b/src/components/WithLabel/WithLabel.tsx
@@ -1,10 +1,6 @@
 import { TypographyProps } from "@mui/material";
-import styled from "@emotion/styled";
 import Text from "@/components/Text";
-
-const Container = styled.div`
-  width: ${({ width }: { width?: number }) => `${width}px`};
-`;
+import { Container } from "./WithLabel.style";
 
 interface WithLabelProps {
   variant?: TypographyProps["variant"];

--- a/src/components/WithLabel/WithLabel.tsx
+++ b/src/components/WithLabel/WithLabel.tsx
@@ -1,0 +1,31 @@
+import { TypographyProps } from "@mui/material";
+import styled from "@emotion/styled";
+import Text from "@/components/Text";
+
+const Container = styled.div`
+  width: ${({ width }: { width?: number }) => `${width}px`};
+`;
+
+interface WithLabelProps {
+  variant?: TypographyProps["variant"];
+  label: string;
+  children: any;
+  wd?: number;
+}
+
+const WithLabel = ({
+  variant = "h5",
+  label,
+  children,
+  wd,
+  ...props
+}: WithLabelProps) => {
+  return (
+    <Container width={wd} {...props}>
+      <Text variant={variant}>{label}</Text>
+      {children}
+    </Container>
+  );
+};
+
+export default WithLabel;

--- a/src/components/WithLabel/index.ts
+++ b/src/components/WithLabel/index.ts
@@ -1,0 +1,3 @@
+import WithLabel from "./WithLabel";
+
+export default WithLabel;

--- a/src/pages/RegisterPage/components/RegisterForm/RegisterForm.style.ts
+++ b/src/pages/RegisterPage/components/RegisterForm/RegisterForm.style.ts
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+
+export const StyledForm = styled.form`
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;

--- a/src/pages/RegisterPage/components/RegisterForm/RegisterForm.style.ts
+++ b/src/pages/RegisterPage/components/RegisterForm/RegisterForm.style.ts
@@ -1,8 +1,21 @@
 import styled from "@emotion/styled";
 
 export const StyledForm = styled.form`
-  padding: 40px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+  padding: 2.5rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  row-gap: 2rem;
+  column-gap: 1rem;
+
+  div:nth-child(5) {
+    grid-column: 1 / span 2;
+  }
+
+  div:nth-child(6) {
+    grid-column: 1 / span 2;
+  }
+
+  button:nth-child(7) {
+    grid-column: 1 / span 2;
+  }
 `;

--- a/src/pages/RegisterPage/components/RegisterForm/RegisterForm.tsx
+++ b/src/pages/RegisterPage/components/RegisterForm/RegisterForm.tsx
@@ -1,5 +1,4 @@
 import { useForm } from "react-hook-form";
-import styled from "@emotion/styled";
 import { useNavigate } from "react-router-dom";
 import Input from "@/components/Input";
 import Select from "@/components/Select";
@@ -14,13 +13,7 @@ import {
   RadioIconButton,
   regionOptions,
 } from "../../registerService";
-
-const StyledForm = styled.form`
-  padding: 40px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-`;
+import { StyledForm } from "./RegisterForm.style";
 
 const RegisterForm = () => {
   const {

--- a/src/pages/RegisterPage/components/RegisterForm/RegisterForm.tsx
+++ b/src/pages/RegisterPage/components/RegisterForm/RegisterForm.tsx
@@ -7,7 +7,7 @@ import ButtonCheckBoxGroup from "@/components/ButtonCheckBoxGroup";
 import WithLabel from "@/components/WithLabel";
 import Radio from "@/components/Radio";
 import { bicycleTypeData, levelData } from "@/constants/data";
-import user from "@/api/user";
+import user, { RegisterData } from "@/api/user";
 import {
   getYearOptions,
   MenuProps,
@@ -23,7 +23,12 @@ const StyledForm = styled.form`
 `;
 
 const RegisterForm = () => {
-  const { register, handleSubmit, setValue } = useForm();
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<RegisterData>();
   const navigate = useNavigate();
 
   const onSubmit = async (data: any) => {
@@ -40,15 +45,21 @@ const RegisterForm = () => {
             minLength: { value: 2, message: "최소 2글자 이상 작성해주세요" },
             maxLength: { value: 8, message: "최대 8글자 이하로 작성해주세요" },
           })}
+          error={!!errors?.nickname}
+          errorMessage={errors?.nickname?.message}
         />
       </WithLabel>
       <WithLabel label="전화번호">
         <Input
           {...register("phoneNumber", {
             required: "필요 데이터",
-            // valueAsNumber: true,
-            maxLength: { value: 11, message: "최대 11글자 제한" },
+            pattern: {
+              value: /^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$/,
+              message: "올바른 핸드폰 번호를 입력해주세요",
+            },
           })}
+          error={!!errors?.phoneNumber}
+          errorMessage={errors?.phoneNumber?.message}
         />
       </WithLabel>
       <WithLabel label="시작년도" wd={200}>

--- a/src/pages/RegisterPage/components/RegisterForm/RegisterForm.tsx
+++ b/src/pages/RegisterPage/components/RegisterForm/RegisterForm.tsx
@@ -14,6 +14,7 @@ import {
   regionOptions,
 } from "../../registerService";
 import { StyledForm } from "./RegisterForm.style";
+import Button from "@/components/Button";
 
 const RegisterForm = () => {
   const {
@@ -95,13 +96,13 @@ const RegisterForm = () => {
           variant="outlined"
           btnColor="#999"
           checkedBtnColor="primary"
+          direction="horizontal"
           {...register("bicycles")}
         />
       </WithLabel>
-
-      <div>
-        <button type="submit">제출</button>
-      </div>
+      <Button type="submit" size="large">
+        제출
+      </Button>
     </StyledForm>
   );
 };

--- a/src/pages/RegisterPage/components/RegisterForm/RegisterForm.tsx
+++ b/src/pages/RegisterPage/components/RegisterForm/RegisterForm.tsx
@@ -1,0 +1,101 @@
+import { useForm } from "react-hook-form";
+import styled from "@emotion/styled";
+import Input from "@/components/Input";
+import Select from "@/components/Select";
+import ButtonCheckBoxGroup from "@/components/ButtonCheckBoxGroup";
+import WithLabel from "@/components/WithLabel";
+import Radio from "@/components/Radio";
+import { bicycleTypeData, levelData } from "@/constants/data";
+import {
+  getYearOptions,
+  MenuProps,
+  RadioIconButton,
+  regionOptions,
+} from "../../registerService";
+
+const StyledForm = styled.form`
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const RegisterForm = () => {
+  const { register, handleSubmit, setValue } = useForm();
+
+  const onSubmit = (data: any) => {
+    console.log(data);
+  };
+
+  return (
+    <StyledForm onSubmit={handleSubmit(onSubmit)}>
+      <WithLabel label="닉네임">
+        <Input
+          {...register("nickname", {
+            required: "필요 데이터",
+            minLength: { value: 2, message: "최소 2글자 이상 작성해주세요" },
+            maxLength: { value: 8, message: "최대 8글자 이하로 작성해주세요" },
+          })}
+        />
+      </WithLabel>
+      <WithLabel label="전화번호">
+        <Input
+          {...register("phoneNumber", {
+            required: "필요 데이터",
+            // valueAsNumber: true,
+            maxLength: { value: 11, message: "최대 11글자 제한" },
+          })}
+        />
+      </WithLabel>
+      <WithLabel label="시작년도" wd={200}>
+        <Select
+          data={getYearOptions(1980, 2022)}
+          MenuProps={MenuProps}
+          {...register("ridingStartYear")}
+        />
+      </WithLabel>
+      <WithLabel label="선호지역" wd={200}>
+        <Select
+          data={regionOptions}
+          MenuProps={MenuProps}
+          {...register("favoriteRegionCode")}
+        />
+      </WithLabel>
+      <WithLabel label="실력">
+        <Radio
+          id="level"
+          data={levelData}
+          row
+          useCustomIcon
+          icon={RadioIconButton}
+          checkedIcon={RadioIconButton}
+          defaultValue={levelData[1].value}
+          {...register("level", {
+            required: "필요 데이터",
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+              setValue("level", e.target.value);
+            },
+          })}
+        />
+      </WithLabel>
+      <WithLabel label="자전거 종류">
+        <ButtonCheckBoxGroup
+          data={bicycleTypeData.map((type) => ({
+            ...type,
+            others: { btnStyle: { width: "6rem" }, style: {} },
+          }))}
+          variant="outlined"
+          btnColor="#999"
+          checkedBtnColor="primary"
+          {...register("bicycles")}
+        />
+      </WithLabel>
+
+      <div>
+        <button type="submit">제출</button>
+      </div>
+    </StyledForm>
+  );
+};
+
+export default RegisterForm;

--- a/src/pages/RegisterPage/components/RegisterForm/RegisterForm.tsx
+++ b/src/pages/RegisterPage/components/RegisterForm/RegisterForm.tsx
@@ -1,11 +1,13 @@
 import { useForm } from "react-hook-form";
 import styled from "@emotion/styled";
+import { useNavigate } from "react-router-dom";
 import Input from "@/components/Input";
 import Select from "@/components/Select";
 import ButtonCheckBoxGroup from "@/components/ButtonCheckBoxGroup";
 import WithLabel from "@/components/WithLabel";
 import Radio from "@/components/Radio";
 import { bicycleTypeData, levelData } from "@/constants/data";
+import user from "@/api/user";
 import {
   getYearOptions,
   MenuProps,
@@ -22,9 +24,11 @@ const StyledForm = styled.form`
 
 const RegisterForm = () => {
   const { register, handleSubmit, setValue } = useForm();
+  const navigate = useNavigate();
 
-  const onSubmit = (data: any) => {
-    console.log(data);
+  const onSubmit = async (data: any) => {
+    await user.register(data);
+    navigate("/", { replace: true });
   };
 
   return (

--- a/src/pages/RegisterPage/components/RegisterForm/index.ts
+++ b/src/pages/RegisterPage/components/RegisterForm/index.ts
@@ -1,0 +1,3 @@
+import RegisterForm from "./RegisterForm";
+
+export default RegisterForm;

--- a/src/pages/RegisterPage/index.tsx
+++ b/src/pages/RegisterPage/index.tsx
@@ -1,5 +1,11 @@
+import RegisterForm from "./components/RegisterForm";
+
 function RegisterPage() {
-  return <div>RegisterPage</div>;
+  return (
+    <div>
+      <RegisterForm />
+    </div>
+  );
 }
 
 export default RegisterPage;

--- a/src/pages/RegisterPage/registerService.tsx
+++ b/src/pages/RegisterPage/registerService.tsx
@@ -1,0 +1,43 @@
+import Button from "@/components/Button";
+import { regionCode } from "@/constants/region";
+
+export const getYearOptions = (start: number, end: number) => {
+  const yearOptions = [];
+  for (let year = start; year <= end; year += 1) {
+    yearOptions.push({
+      key: year,
+      value: year,
+      text: `${String(year)}년`,
+    });
+  }
+  return yearOptions.reverse();
+};
+
+export const regionOptions = regionCode.map((region) => ({
+  key: region.code,
+  value: region.code,
+  text: region.name,
+}));
+
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+export const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+    },
+  },
+};
+
+export const RadioIconButton = ({
+  label,
+  type,
+}: {
+  label: string | number;
+  type: string;
+}) =>
+  type === "checked" ? (
+    <Button customColor="primary">{label}</Button>
+  ) : (
+    <Button customColor="#999">{label}</Button>
+  );


### PR DESCRIPTION
## **📌 PR 설명**
유저스토리 
- [x] 최초로 카카오 로그인한 사용자는 더 나은 서비스 이용을 위한 추가 정보를 입력한다.
- [x] 닉네임(필수), 전화번호(필수), 자전거 취미 시작 년도, 선호지역, 숙련도, 자전거 종류, 프로필이미지, 자기소개를 입력할 수 있다.

## **💻 요구 사항과 구현 내용**
WithLabel 컴포넌트
- form Input의 label을 달아주는 부분이 자주 재사용되어, 공통 컴포넌트화 하였습니다.
- label, varient, width를 prop으로 받고, 사용하려는 input컴포넌트를 Children으로 받아 사용합니다.

RegisterForm 구현
- 기존에 만들어져있는 Form Component들을 최대한으로 사용하여, 구성하였습니다.
- 현재 레이아웃/디자인은 별도 issue로 분리하여, 신경쓰지 않았습니다. 기능동작만 봐주시면 좋을 것 같아요.

register API 연동
- form제출 시, 모든 data를 API 요청으로 한 번에 보내도록 하였으며, 성공 시 메인페이지로 이동합니다.

닉네임 전화번호 validation 추가
- 닉네임은 2자 이상 8자 이하로,
- 전화번호는 정규표현식을 사용하여 validation 추가하였습니다. 
## **✔️ PR 포인트 & 궁금한 점**
- Form 관련 공통 컴포넌트들 올바르게 사용하였는지 궁금합니다.
- Form Validation 추가해야할 부분 있다면 말씀부탁드려요.
- registerPage에서만 사용하는 상수, util함수들은 registerService에 작성하였는데, 이 패턴은 어떠한지 궁금합니다.
 만족스럽다면, 전체적으로 적용할 수 있을 것 같고, 그렇지 않다면 수정 필요해서 의견궁금합니다.