### PR TITLE
[feat] 라이딩 모집글 수정 기능 구현 #30 

### DIFF
--- a/src/@types/response.d.ts
+++ b/src/@types/response.d.ts
@@ -18,6 +18,7 @@ declare module "response" {
     riding: {
       title: string;
       thumbnail: string;
+      thumbnailId: number | null;
       ridingLevel: string;
       zone: {
         code: number;

--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -20,3 +20,15 @@ export const postPost = async (
   });
   return response.data;
 };
+
+export const editPost = async (
+  postId: number,
+  postData: RidingFormValues
+): Promise<T.PostDetail> => {
+  const response = await axiosInstance({
+    method: "PUT",
+    url: `/api/v1/ridingposts/${postId}`,
+    data: postData,
+  });
+  return response.data;
+};

--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -2,7 +2,7 @@ import * as T from "response";
 import { RidingFormValues } from "@/pages/PostPage/components/postForm/PostForm";
 import axiosInstance from "./axiosInstance";
 
-export const getPosts = async (postId: number): Promise<T.PostDetail> => {
+export const getPost = async (postId: number): Promise<T.PostDetail> => {
   const response = await axiosInstance({
     method: "GET",
     url: `/api/v1/ridingposts/${postId}`,
@@ -10,7 +10,7 @@ export const getPosts = async (postId: number): Promise<T.PostDetail> => {
   return response.data;
 };
 
-export const postPosts = async (
+export const postPost = async (
   postData: RidingFormValues
 ): Promise<T.PostDetail> => {
   const response = await axiosInstance({

--- a/src/pages/PostEditPage/index.tsx
+++ b/src/pages/PostEditPage/index.tsx
@@ -1,5 +1,99 @@
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { SubmitHandler } from "react-hook-form";
+import dayjs from "dayjs";
+import { editPost, getPost } from "@/api/posts";
+import { PostForm } from "../PostPage/components";
+import { RidingFormValues } from "../PostPage/components/postForm/PostForm";
+import Spinner from "@/components/Spinner";
+
 function PostEditPage() {
-  return <div>PostEditPage</div>;
+  const { postId } = useParams();
+  const navigate = useNavigate();
+  const [ridingData, setRidingData] = useState<RidingFormValues>();
+  const [urlData, setUrlData] =
+    useState<{
+      details?: string[][];
+      thumbnail?: string;
+    }>();
+  useQuery(
+    ["riding-edit", postId],
+    () => getPost(postId ? parseInt(postId, 10) : 0),
+    {
+      onSuccess: (value) => {
+        const {
+          riding: {
+            bicycleType,
+            departurePosition,
+            estimatedTime,
+            fee,
+            minParticipant,
+            maxParticipant,
+            ridingCourses,
+            ridingDate,
+            ridingLevel,
+            thumbnail,
+            thumbnailId,
+            title,
+            zone,
+            details,
+          },
+        } = value;
+
+        const formUrls = {
+          details: details.map((item) =>
+            item.images.map((image) => image.imageUrl)
+          ),
+          thumbnail,
+        };
+        setUrlData(formUrls);
+        const detailsValue = details.map((item) => ({
+          title: item.title,
+          images: item.images.map((image) => image.id),
+          content: item.contents,
+        }));
+
+        const formattedDate = dayjs(ridingDate).format("YYYY-MM-DDTHH:mm");
+        const FormData = {
+          information: {
+            bicycleTypes: bicycleType,
+            departurePlace: departurePosition,
+            minParticipantCount: minParticipant,
+            maxParticipantCount: maxParticipant,
+            routes: ridingCourses,
+            level: ridingLevel,
+            regionCode: zone.code,
+            ridingDate: formattedDate,
+            estimatedTime,
+            fee,
+            thumbnail: thumbnailId,
+            title,
+          },
+          details: detailsValue,
+        };
+        setRidingData(FormData);
+      },
+    }
+  );
+
+  const handleSubmit: SubmitHandler<RidingFormValues> = (data) => {
+    if (!postId) return;
+    editPost(parseInt(postId, 10), data);
+    navigate(`/post/${postId}`);
+  };
+
+  return !ridingData ? (
+    <Spinner />
+  ) : (
+    <div>
+      <PostForm
+        defaultValues={ridingData}
+        onSubmit={handleSubmit}
+        defaultUrl={urlData}
+      />
+    </div>
+  );
 }
 
 export default PostEditPage;

--- a/src/pages/PostPage/components/postForm/PostForm.tsx
+++ b/src/pages/PostPage/components/postForm/PostForm.tsx
@@ -254,7 +254,8 @@ function PostForm({
                 <FeeInput
                   {...props}
                   onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                    onChange(parseInt(e.target.value, 10) || 0);
+                    if (!e) onChange(0);
+                    else onChange(parseInt(e.target.value, 10) || 0);
                   }}
                 />
               )}

--- a/src/pages/PostPage/components/postForm/PostForm.tsx
+++ b/src/pages/PostPage/components/postForm/PostForm.tsx
@@ -138,8 +138,8 @@ function PostForm({
               rules={{
                 validate: {
                   afterNow: (value) =>
-                    dayjs(value).diff(dayjs()) > 0 ||
-                    "현재 시간 이전은 선택할 수 없습니다.",
+                    dayjs(value).diff(dayjs().add(1, "day")) > 0 ||
+                    "24시간 이후 시간만 가능합니다.",
                 },
               }}
             />

--- a/src/pages/PostPage/components/postForm/PostForm.tsx
+++ b/src/pages/PostPage/components/postForm/PostForm.tsx
@@ -6,7 +6,6 @@ import {
 } from "react-hook-form";
 import dayjs from "dayjs";
 import { ChangeEvent } from "react";
-import utc from "dayjs/plugin/utc";
 import Input from "@/components/Input";
 import DatePicker from "@/components/DatePicker";
 import Button from "@/components/Button";
@@ -26,9 +25,6 @@ import { Form, TwoColumnContainer } from "./PostForm.style";
 import WithLabel from "@/components/WithLabel";
 import { estimatedTime } from "@/constants/data";
 import Select from "@/components/Select";
-import defaultThumbnail from "@/assets/RG_Logo.png";
-
-dayjs.extend(utc);
 
 type Section = {
   title: string;
@@ -122,9 +118,7 @@ function PostForm({
                 <DatePicker
                   onChange={(e: ChangeEvent<HTMLInputElement>) => {
                     onChange(
-                      dayjs(e.target.value)
-                        .utc()
-                        .format("YYYY-MM-DDTHH:mm:ss.SSS[Z]")
+                      dayjs(e.target.value).format("YYYY-MM-DDTHH:mm:ss.SSS")
                     );
                   }}
                   error={!!errors.information?.ridingDate}
@@ -134,7 +128,7 @@ function PostForm({
               rules={{
                 validate: {
                   afterNow: (value) =>
-                    dayjs(value).utc().diff(dayjs().utc()) > 0 ||
+                    dayjs(value).diff(dayjs()) > 0 ||
                     "현재 시간 이전은 선택할 수 없습니다.",
                 },
               }}

--- a/src/pages/PostPage/components/postForm/PostForm.tsx
+++ b/src/pages/PostPage/components/postForm/PostForm.tsx
@@ -31,7 +31,10 @@ type Section = {
   images: number[];
   content: string;
 };
-
+type FormImageUrl = {
+  details?: string[][];
+  thumbnail?: string;
+};
 export interface RidingFormValues {
   information: {
     title: string;
@@ -56,6 +59,7 @@ export interface RidingFormValues {
 interface PostFormProps {
   onSubmit: SubmitHandler<RidingFormValues>;
   defaultValues?: Partial<RidingFormValues>;
+  defaultUrl?: FormImageUrl;
 }
 
 function PostForm({
@@ -63,6 +67,7 @@ function PostForm({
   defaultValues = {
     details: [{ title: "", images: [], content: "" }],
   },
+  defaultUrl,
 }: PostFormProps) {
   const methods = useForm<RidingFormValues>({
     defaultValues,
@@ -73,7 +78,6 @@ function PostForm({
     handleSubmit,
     formState: { errors },
   } = methods;
-  console.log(errors);
   return (
     <FormProvider {...methods}>
       <Form>
@@ -81,7 +85,13 @@ function PostForm({
           control={control}
           name="information.thumbnail"
           render={({ field }) => (
-            <ThumbnailInput {...field} defaultUrl={defaultThumbnail} />
+            <ThumbnailInput
+              {...field}
+              defaultUrl={
+                defaultUrl?.thumbnail ||
+                "https://team-05-storage.s3.ap-northeast-2.amazonaws.com/static/RG_Logo.png"
+              }
+            />
           )}
           defaultValue={null}
         />
@@ -299,7 +309,7 @@ function PostForm({
           label="상세 내용"
           labelProps={{ marginBottom: true }}
         >
-          <ExpandableInput />
+          <ExpandableInput imageUrls={defaultUrl?.details} />
         </WithLabel>
         <Button type="button" onClick={handleSubmit(onSubmit)}>
           저장하기

--- a/src/pages/PostPage/components/postForm/components/ExpandableInput/ExpandableInput.tsx
+++ b/src/pages/PostPage/components/postForm/components/ExpandableInput/ExpandableInput.tsx
@@ -10,7 +10,11 @@ import Button from "@/components/Button";
 import ImageInput from "./ImageInput";
 import { RidingFormValues } from "../../PostForm";
 
-function ExpandableInput() {
+interface ExpandableInputProps {
+  imageUrls?: string[][];
+}
+
+function ExpandableInput({ imageUrls }: ExpandableInputProps) {
   const { control, register, getFieldState } =
     useFormContext<RidingFormValues>();
   const { fields, append, remove } = useFieldArray({
@@ -53,6 +57,7 @@ function ExpandableInput() {
                     value={value}
                     inputRef={ref}
                     imageLimit={2}
+                    defaultImages={imageUrls?.at(index)}
                   />
                 )}
                 name={`details.${index}.images`}

--- a/src/pages/PostPage/components/postForm/components/ExpandableInput/ImageInput.tsx
+++ b/src/pages/PostPage/components/postForm/components/ExpandableInput/ImageInput.tsx
@@ -16,6 +16,7 @@ interface ImageInputProps extends InputHTMLAttributes<HTMLInputElement> {
   value?: any;
   onChange?: (...event: any[]) => void;
   inputRef?: any;
+  defaultImages?: string[];
 }
 
 const ImageInput = ({
@@ -24,9 +25,18 @@ const ImageInput = ({
   imageLimit,
   value,
   onChange,
+  defaultImages,
   inputRef,
 }: ImageInputProps) => {
-  const [imageList, setImageList] = useState<Image[]>([]);
+  const [imageList, setImageList] = useState<Image[]>(
+    defaultImages
+      ? defaultImages.map((image, index) => ({
+          url: image,
+          id: value[index],
+          originalFileName: value[index],
+        }))
+      : []
+  );
   const [customError, setCustomError] = useState<{
     error: boolean;
     errorMessage: string;

--- a/src/pages/PostPage/components/postForm/components/FeeInput/FeeInput.tsx
+++ b/src/pages/PostPage/components/postForm/components/FeeInput/FeeInput.tsx
@@ -19,7 +19,7 @@ const FeeInput = forwardRef<HTMLInputElement, FeeInputProps>(
             customColor={isPaid ? "#999" : "primary"}
             onClick={() => {
               setPaid(false);
-              if (onChange) onChange(0);
+              if (onChange) onChange();
             }}
           >
             없음

--- a/src/pages/PostPage/components/postForm/components/RegionInput/RegionInput.tsx
+++ b/src/pages/PostPage/components/postForm/components/RegionInput/RegionInput.tsx
@@ -12,7 +12,9 @@ interface RegionInputProps {
 
 const RegionInput = forwardRef<HTMLInputElement, RegionInputProps>(
   ({ onChange, value, error, errorMessage }, ref) => {
-    const [city, setCity] = useState<number>(0);
+    const [city, setCity] = useState<number>(
+      value ? Math.floor(value / 1000) : 0
+    );
 
     const detailData = useMemo(() => {
       const result = regionCode
@@ -22,7 +24,7 @@ const RegionInput = forwardRef<HTMLInputElement, RegionInputProps>(
           value: code,
           text: name,
         }));
-      return result || [{ key: 0, value: 0, text: "" }];
+      return result || [];
     }, [city]);
 
     return (

--- a/src/pages/PostPage/components/postForm/components/RouteInput/RouteInput.tsx
+++ b/src/pages/PostPage/components/postForm/components/RouteInput/RouteInput.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useState } from "react";
+import { ChangeEvent, forwardRef, useCallback, useState } from "react";
 import { Breadcrumbs, Icon } from "@mui/material";
 import { Container } from "./RouteInput.style";
 import Input from "@/components/Input";
@@ -18,14 +18,13 @@ const RouteInput = forwardRef<HTMLInputElement, RouteInputProps>(
       error: boolean;
       message: string;
     }>({ error: false, message: "" });
+    const [inputValue, setInputValue] = useState<string>("");
 
     const handleKeydown = useCallback(
-      (e: KeyboardEvent) => {
+      (e: any) => {
         setCustomError({ error: false, message: "" });
         if (e.key !== "Enter") return;
-        if (!(e.target instanceof HTMLInputElement)) return;
         e.preventDefault();
-        const inputValue = e.target.value;
 
         if (inputValue.length < 1) {
           setCustomError({ error: true, message: "1글자 이상 입력해주세요" });
@@ -41,10 +40,10 @@ const RouteInput = forwardRef<HTMLInputElement, RouteInputProps>(
           });
         } else {
           onChange([...value, inputValue]);
-          e.target.value = "";
+          setInputValue("");
         }
       },
-      [onChange, value]
+      [inputValue, onChange, value]
     );
 
     return (
@@ -52,6 +51,10 @@ const RouteInput = forwardRef<HTMLInputElement, RouteInputProps>(
         <Container>
           <Input
             fullWidth
+            value={inputValue}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setInputValue(e.target.value);
+            }}
             onKeyDown={handleKeydown}
             onBlur={() => {
               if (onBlur) onBlur();

--- a/src/pages/PostPage/index.tsx
+++ b/src/pages/PostPage/index.tsx
@@ -5,7 +5,7 @@ import { SubmitHandler } from "react-hook-form";
 import { PostForm } from "./components";
 import { RidingFormValues } from "./components/postForm/PostForm";
 import auth from "@/api/auth";
-import { postPosts } from "@/api/posts";
+import { postPost } from "@/api/posts";
 
 const Container = styled.div`
   margin: auto;
@@ -28,7 +28,7 @@ function PostPage() {
   }, []);
 
   const handleSubmit: SubmitHandler<RidingFormValues> = async (data) => {
-    const postId = await postPosts(data);
+    const postId = await postPost(data);
     navigate(`/post/${postId}`, { replace: true });
   };
   return (

--- a/src/pages/RidingDetail/components/SideInfo/SideInfo.tsx
+++ b/src/pages/RidingDetail/components/SideInfo/SideInfo.tsx
@@ -103,7 +103,6 @@ const SideInfo = ({ data }: SideInfoProps) => {
   const { open, handleOpen, handleClose } = useModal();
 
   const onSubmit = () => {
-    console.log("submitted!");
     handleClose();
   };
 

--- a/src/pages/RidingDetail/index.tsx
+++ b/src/pages/RidingDetail/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Grid } from "@mui/material";
 import { useParams } from "react-router-dom";
-import { getPosts } from "@/api/posts";
+import { getPost } from "@/api/posts";
 import Header from "./components/Header";
 import SideInfo from "./components/SideInfo";
 import MainInfo from "./components/MainInfo";
@@ -27,9 +27,10 @@ const RidingDetail = ({ postId = 1 }: Props) => {
     isLoading,
   } = useQuery(
     ["riding-detail", id || postId],
-    () => getPosts(Number(id) || postId),
+    () => getPost(Number(id) || postId),
     {
       onSuccess: (data) => {
+        console.log("디테일", data);
         const {
           title,
           thumbnail,

--- a/src/pages/RidingDetail/index.tsx
+++ b/src/pages/RidingDetail/index.tsx
@@ -30,7 +30,6 @@ const RidingDetail = ({ postId = 1 }: Props) => {
     () => getPost(Number(id) || postId),
     {
       onSuccess: (data) => {
-        console.log("디테일", data);
         const {
           title,
           thumbnail,


### PR DESCRIPTION
## **📌 PR 설명**
라이딩 모집글 수정 기능을 추가했습니다.
## **💻 요구 사항과 구현 내용**
- [x] 입력 폼에 기존 라이딩 포스트 값들을 기본값으로 설정
- [x] 수정 한 값이 폼의 값에 적용
- [x] 수정된 값을 api로 전송
- [x] 전송 후 수정한 페이지의 디테일 페이지로 이동
